### PR TITLE
fix sourcePlatform to be in Dataset domain

### DIFF
--- a/ontology-files/earthcollab_schema.ttl
+++ b/ontology-files/earthcollab_schema.ttl
@@ -30,6 +30,13 @@ ec:sourcePlatform a owl:ObjectProperty ;
 	rdfs:domain gcis:Dataset ;
 	rdfs:range gcis:Platform .
 
+ec:sourcePlatformFor a owl:ObjectProperty ;
+	rdfs:label "Source Platform For" ;
+	rdfs:comment "Inverse property of gcis:sourcePlatform, needed to enable VIVO to display the relationship on both the platform and dataset page." ;
+	owl:inverseOf gcis:sourcePlatform ;
+	rdfs:domain gcis:Platform ;
+	rdfs:range gcis:Dataset .
+
 ec:Parameter a owl:Class;
 	rdfs:label "Parameter" ;
 	rdfs:comment "A measured physical property." ;

--- a/ontology-files/earthcollab_schema.ttl
+++ b/ontology-files/earthcollab_schema.ttl
@@ -27,6 +27,7 @@ ec:Project a owl:Class ;
 ec:sourcePlatform a owl:ObjectProperty ;
 	rdfs:label "Source Platform" ;
 	rdfs:comment "A dataset was collected using an observational platform." ;
+	rdfs:domain gcis:Dataset ;
 	rdfs:range gcis:Platform .
 
 ec:Parameter a owl:Class;


### PR DESCRIPTION
I think this is really how we wanted to relate `Platform`s and `Dataset`s. As-is, it seems that `ec:sourcePlatform` doesn't do anything more than `gcis:Platform`.

Implemented on the [EOL dev site](http://vivo.dev.eol.ucar.edu/vivo/). Perhaps @cbsnyder can provide some good example links.